### PR TITLE
feat: add terminal theming support and configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ with demo:
 |----------|------------|-------------|
 | `launch_terminal()` | `port=5000`, `host="127.0.0.1"`, `command="bash"`, `share=False`, `allow_sudo=True`, `blacklist_commands=None`, `**launch_kwargs` | Launch a standalone Gradio app with a terminal. |
 | `create_terminal_demo()` | `port=5000`, `host="127.0.0.1"`, `command="bash"`, `height=400`, `allow_sudo=True`, `blacklist_commands=None` | Create a Gradio Blocks demo with an embedded terminal. |
-| `Terminal()` | `port=5000`, `host="127.0.0.1"`, `command="bash"`, `height=400`, `label=None`, `visible=True`, `elem_id=None`, `elem_classes=None`, `allow_sudo=True`, `blacklist_commands=None` | Create a terminal component for Gradio Blocks. |
-| `TerminalServer()` | `port=5000`, `host="127.0.0.1"`, `command="bash"` | Low-level terminal server for custom integrations. |
+| `Terminal()` | `port=5000`, `host="127.0.0.1"`, `command="bash"`, `height=400`, `label=None`, `visible=True`, `elem_id=None`, `elem_classes=None`, `allow_sudo=True`, `blacklist_commands=None`, `theme="dark"`, `xterm_options=None`, `allow_unsafe_werkzeug=False` | Create a terminal component for Gradio Blocks. |
+| `TerminalServer()` | `port=5000`, `host="127.0.0.1"`, `command="bash"`, `theme="dark"`, `xterm_options=None`, `allow_unsafe_werkzeug=False` | Low-level terminal server for custom integrations. |
 
 ### TerminalServer Methods
 
@@ -62,6 +62,9 @@ with demo:
 
 - `allow_sudo`: Whether to allow sudo commands (default: True). When False, sudo commands are blocked with an error message.
 - `blacklist_commands`: List of commands to block (default: None). Any command in this list will be blocked with an error message.
+- `theme`: Visual theme ('dark' or 'light', default: 'dark').
+- `xterm_options`: Optional dictionary of xterm.js options. Can be used to set `fontSize`, `fontFamily`, or override theme colors via a nested `theme` key (e.g., `{"fontSize": 16, "theme": {"background": "#FF0000"}}`). See the [official xterm.js documentation](https://xtermjs.org/docs/api/terminal/interfaces/iterminaloptions/) for a full list of available options.
+- `allow_unsafe_werkzeug`: Whether to allow running the development server in 'unsafe' mode (default: False). This is helpful when running an independent `Terminal` or `TerminalServer` instance outside of a main Gradio app. Use with caution.
 
 ## Security
 

--- a/demo/app_theme.py
+++ b/demo/app_theme.py
@@ -1,0 +1,16 @@
+import gradio as gr
+from gradio_terminal import Terminal
+
+with gr.Blocks() as demo:
+    gr.Markdown("# Terminal Theme and Font Size Demo")
+
+    with gr.Row():
+        with gr.Column():
+            gr.Markdown("### Dark Theme (Default)")
+            Terminal(port=5000, theme="dark")
+
+        with gr.Column():
+            gr.Markdown("### Light Theme, Large Font")
+            Terminal(port=5001, theme="light", xterm_options={"fontSize": 16})
+
+demo.launch()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dev = [
     "pytest>=7.0.0",
     "black>=22.0.0",
     "flake8>=4.0.0",
+    "requests",
 ]
 
 [project.urls]

--- a/src/gradio_terminal/terminal.py
+++ b/src/gradio_terminal/terminal.py
@@ -77,10 +77,21 @@ class TerminalServer:
     Runs Flask-SocketIO in a background thread.
     """
 
-    def __init__(self, port: int = 5000, host: str = "127.0.0.1", command: str = "bash"):
+    def __init__(
+        self,
+        port: int = 5000,
+        host: str = "127.0.0.1",
+        command: str = "bash",
+        theme: str = "dark",
+        xterm_options: dict | None = None,
+        allow_unsafe_werkzeug: bool = False,
+    ):
         self.port = port
         self.host = host
         self.command = command
+        self.theme = theme
+        self.xterm_options = xterm_options or {}
+        self.allow_unsafe_werkzeug = allow_unsafe_werkzeug
         self.allow_sudo = True
         self.blacklist_commands = []
         self._running = False
@@ -226,52 +237,122 @@ class TerminalServer:
 
         return app, socketio
 
+    def _get_xterm_theme_json(self) -> str:
+        import json
+
+        if self.theme == "dark":
+            theme = {
+                "background": "#1E1E1E",
+                "foreground": "#D4D4D4",
+                "cursor": "#D4D4D4",
+                "cursorAccent": "#1E1E1E",
+                "selectionBackground": "rgba(255, 255, 255, 0.3)",
+                "black": "#2E3436",
+                "red": "#CC0000",
+                "green": "#4E9A06",
+                "yellow": "#C4A000",
+                "blue": "#3465A4",
+                "magenta": "#75507B",
+                "cyan": "#06989A",
+                "white": "#D3D7CF",
+                "brightBlack": "#555753",
+                "brightRed": "#EF2929",
+                "brightGreen": "#8AE234",
+                "brightYellow": "#FCE94F",
+                "brightBlue": "#729FCF",
+                "brightMagenta": "#AD7FA8",
+                "brightCyan": "#34E2E2",
+                "brightWhite": "#EEEEEC",
+            }
+        else:
+            theme = {
+                "background": "#EAECDD",
+                "foreground": "#40453E",
+                "cursor": "#00BBEC",
+                "cursorAccent": "#F7FEE7",
+                "selectionBackground": "#40504040",
+                "black": "#2F3126",
+                "red": "#FF8080",
+                "green": "#16a34a",
+                "yellow": "#b45309",
+                "blue": "#1E90FF",
+                "magenta": "#FF1493",
+                "cyan": "#047857",
+                "white": "#A7A697",
+                "brightBlack": "#5A5E57",
+                "brightRed": "#FF9999",
+                "brightGreen": "#22C55E",
+                "brightYellow": "#D97706",
+                "brightBlue": "#60A5FA",
+                "brightMagenta": "#F472B6",
+                "brightCyan": "#10B981",
+                "brightWhite": "#E0E1D4",
+            }
+
+        config = {
+            "theme": theme,
+        }
+
+        user_options = {k: v for k, v in self.xterm_options.items() if k not in ["theme"]}
+        config.update(user_options)
+
+        if "theme" in self.xterm_options and isinstance(self.xterm_options["theme"], dict):
+            config["theme"].update(self.xterm_options["theme"])
+
+        return json.dumps(config)
+
     def _get_terminal_html(self) -> str:
         """Return the HTML template for the terminal."""
-        return """
+        import json
+
+        full_config = json.loads(self._get_xterm_theme_json())
+        bg_color = full_config["theme"].get("background", "#1E1E1E")
+        js_config = json.dumps(full_config)
+
+        return f"""
 <!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="utf-8" />
     <title>Gradio Terminal</title>
     <style>
-        html, body {
+        html, body {{
             margin: 0;
             padding: 0;
             height: 100%;
             overflow: hidden;
-            background-color: #1e1e1e;
-        }
-        #terminal {
+            background-color: {bg_color};
+        }}
+        #terminal {{
             width: 100%;
             height: 100%;
-        }
-        #status {
+        }}
+        #status {{
             position: absolute;
             top: 5px;
             right: 10px;
             font-size: 12px;
             font-family: Arial, sans-serif;
             z-index: 1000;
-        }
-        .connected {
+        }}
+        .connected {{
             background-color: #4CAF50;
             color: white;
             padding: 2px 8px;
             border-radius: 3px;
-        }
-        .disconnected {
+        }}
+        .disconnected {{
             background-color: #f44336;
             color: white;
             padding: 2px 8px;
             border-radius: 3px;
-        }
-        .connecting {
+        }}
+        .connecting {{
             background-color: #ff9800;
             color: white;
             padding: 2px 8px;
             border-radius: 3px;
-        }
+        }}
     </style>
     <link rel="stylesheet" href="https://unpkg.com/xterm@4.11.0/css/xterm.css" />
 </head>
@@ -285,20 +366,15 @@ class TerminalServer:
     <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/4.0.1/socket.io.min.js"></script>
 
     <script>
-        const term = new Terminal({
+        const config = {js_config}
+        const term = new Terminal({{
+            fontSize: 14,
+            fontFamily: 'Consolas, Monaco, monospace',
             cursorBlink: true,
             macOptionIsMeta: true,
             scrollback: 5000,
-            fontSize: 14,
-            fontFamily: 'Consolas, Monaco, monospace',
-            theme: {
-                background: '#1e1e1e',
-                foreground: '#d4d4d4',
-                cursor: '#d4d4d4',
-                cursorAccent: '#1e1e1e',
-                selectionBackground: 'rgba(255, 255, 255, 0.3)',
-            }
-        });
+            ...config,
+            }});
 
         const fit = new FitAddon.FitAddon();
         term.loadAddon(fit);
@@ -307,70 +383,69 @@ class TerminalServer:
         term.open(document.getElementById("terminal"));
         fit.fit();
 
-        term.attachCustomKeyEventHandler((e) => {
+        term.attachCustomKeyEventHandler((e) => {{
             if (e.type !== "keydown") return true;
-            if (e.ctrlKey && e.shiftKey) {
+            if (e.ctrlKey && e.shiftKey) {{
                 const key = e.key.toLowerCase();
-                if (key === "v") {
-                    navigator.clipboard.readText().then((text) => {
+                if (key === "v") {{
+                    navigator.clipboard.readText().then((text) => {{
                         term.writeText(text);
-                    });
+                    }});
                     return false;
-                } else if (key === "c" || key === "x") {
+                }} else if (key === "c" || key === "x") {{
                     const selection = term.getSelection();
-                    if (selection) {
+                    if (selection) {{
                         navigator.clipboard.writeText(selection);
-                    }
+                    }}
                     return false;
-                }
-            }
+                }}
+            }}
             return true;
-        });
+        }});
 
         const socket = io.connect("/pty");
         const status = document.getElementById("status");
 
-        term.onData((data) => {
-            socket.emit("pty-input", { input: data });
-        });
+        term.onData((data) => {{
+            socket.emit("pty-input", {{ input: data }});
+        }});
 
-        socket.on("pty-output", (data) => {
+        socket.on("pty-output", (data) => {{
             term.write(data.output);
-        });
+        }});
 
-        socket.on("connect", () => {
+        socket.on("connect", () => {{
             status.innerHTML = '<span class="connected">connected</span>';
             fitToScreen();
-        });
+        }});
 
-        socket.on("disconnect", () => {
+        socket.on("disconnect", () => {{
             status.innerHTML = '<span class="disconnected">disconnected</span>';
-        });
+        }});
 
-        socket.on("connect_error", (error) => {
+        socket.on("connect_error", (error) => {{
             status.innerHTML = '<span class="disconnected">error</span>';
-        });
+        }});
 
-        function fitToScreen() {
+        function fitToScreen() {{
             fit.fit();
-            const dims = { cols: term.cols, rows: term.rows };
+            const dims = {{ cols: term.cols, rows: term.rows }};
             socket.emit("resize", dims);
-        }
+        }}
 
-        function debounce(func, wait) {
+        function debounce(func, wait) {{
             let timeout;
-            return function(...args) {
+            return function(...args) {{
                 clearTimeout(timeout);
                 timeout = setTimeout(() => func.apply(this, args), wait);
-            };
-        }
+            }};
+        }}
 
         window.onresize = debounce(fitToScreen, 50);
         setTimeout(fitToScreen, 100);
     </script>
 </body>
-</html>
-"""
+</html>"""
 
     def start(self):
         """Start the terminal server in a background thread."""
@@ -387,6 +462,7 @@ class TerminalServer:
                 debug=False,
                 use_reloader=False,
                 log_output=False,
+                allow_unsafe_werkzeug=self.allow_unsafe_werkzeug,
             )
 
         self._thread = threading.Thread(target=run_server, daemon=True)
@@ -460,6 +536,9 @@ class Terminal:
         elem_classes: list[str] | str | None = None,
         allow_sudo: bool = True,
         blacklist_commands: list[str] | None = None,
+        theme: str = "dark",
+        xterm_options: dict | None = None,
+        allow_unsafe_werkzeug: bool = False,
     ):
         """
         Create a Terminal component.
@@ -475,6 +554,9 @@ class Terminal:
             elem_classes: CSS classes.
             allow_sudo: Whether to allow sudo commands (default: True).
             blacklist_commands: List of commands to block (default: None).
+            theme: Visual theme ('dark' or 'light', default: 'dark').
+            xterm_options: Dictionary of xterm.js options.
+            allow_unsafe_werkzeug: Allow running Werkzeug in unsafe mode (default: False).
         """
         self.port = port
         self.host = host
@@ -486,9 +568,19 @@ class Terminal:
         self.elem_classes = elem_classes
         self.allow_sudo = allow_sudo
         self.blacklist_commands = blacklist_commands or []
+        self.theme = theme
+        self.xterm_options = xterm_options or {}
+        self.allow_unsafe_werkzeug = allow_unsafe_werkzeug
 
         # Start the terminal server
-        self._server = TerminalServer(port=port, host=host, command=command)
+        self._server = TerminalServer(
+            port=port,
+            host=host,
+            command=command,
+            theme=theme,
+            xterm_options=xterm_options,
+            allow_unsafe_werkzeug=allow_unsafe_werkzeug,
+        )
         self._server.allow_sudo = allow_sudo
         self._server.blacklist_commands = self.blacklist_commands
         terminal_url = self._server.start()
@@ -532,6 +624,9 @@ def create_terminal(
     label: str | None = None,
     allow_sudo: bool = True,
     blacklist_commands: list[str] | None = None,
+    theme: str = "dark",
+    xterm_options: dict | None = None,
+    allow_unsafe_werkzeug: bool = False,
 ) -> Terminal:
     """
     Create a terminal component that can be used in Gradio Blocks.
@@ -544,6 +639,9 @@ def create_terminal(
         label: Optional label for the terminal.
         allow_sudo: Whether to allow sudo commands (default: True).
         blacklist_commands: List of commands to block (default: None).
+        theme: Visual theme ('dark' or 'light', default: 'dark').
+        xterm_options: Dictionary of xterm.js options.
+        allow_unsafe_werkzeug: Allow running Werkzeug in unsafe mode (default: False).
 
     Returns:
         A Terminal instance.
@@ -556,6 +654,9 @@ def create_terminal(
         label=label,
         allow_sudo=allow_sudo,
         blacklist_commands=blacklist_commands,
+        theme=theme,
+        xterm_options=xterm_options,
+        allow_unsafe_werkzeug=allow_unsafe_werkzeug,
     )
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,23 @@
+from gradio_terminal import TerminalServer
+
+
+def test_dark_theme_html():
+    server = TerminalServer(theme="dark")
+    config = server._get_xterm_theme_json()
+    assert '"background": "#1E1E1E"' in config
+    assert '"black": "#2E3436"' in config
+
+
+def test_light_theme_html():
+    server = TerminalServer(theme="light", xterm_options={"fontSize": 20})
+    config = server._get_xterm_theme_json()
+    assert '"fontSize": 20' in config
+    assert '"background": "#EAECDD"' in config
+    assert '"black": "#2F3126"' in config
+
+
+def test_default_theme_html():
+    server = TerminalServer()  # defaults to dark, 14
+    config = server._get_xterm_theme_json()
+    assert '"background": "#1E1E1E"' in config
+    assert '"black": "#2E3436"' in config

--- a/tests/test_custom_theme.py
+++ b/tests/test_custom_theme.py
@@ -1,0 +1,12 @@
+from gradio_terminal import TerminalServer
+
+
+def test_custom_theme_colors():
+    custom_colors = {"background": "#FF0000", "foreground": "#00FF00"}
+    server = TerminalServer(theme="dark", xterm_options={"theme": custom_colors})
+    theme_json = server._get_xterm_theme_json()
+
+    assert '"background": "#FF0000"' in theme_json
+    assert '"foreground": "#00FF00"' in theme_json
+    # Ensure non-overridden colors are still there (from dark theme preset)
+    assert '"black": "#2E3436"' in theme_json

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -1,0 +1,32 @@
+import requests
+import pytest
+from gradio_terminal import TerminalServer, Terminal
+
+
+def test_server_start_and_stop():
+    port = 5001
+    server = TerminalServer(port=port, allow_unsafe_werkzeug=True)
+    url = server.start()
+
+    assert url == f"http://127.0.0.1:{port}"
+
+    try:
+        response = requests.get(f"http://127.0.0.1:{port}")
+        assert response.status_code == 200
+    except requests.exceptions.ConnectionError:
+        pytest.fail("TerminalServer failed to start or is not reachable")
+    finally:
+        server.stop()
+
+
+def test_terminal_component_lifecycle():
+    port = 5002
+    terminal = Terminal(port=port, allow_unsafe_werkzeug=True)
+
+    try:
+        response = requests.get(f"http://127.0.0.1:{port}")
+        assert response.status_code == 200
+    except requests.exceptions.ConnectionError:
+        pytest.fail("Terminal component failed to start internal server")
+    finally:
+        terminal.stop()


### PR DESCRIPTION
- Implement theme support ('dark'/'light') for Terminal and TerminalServer.
- Add xterm.js option customization via xterm_options.
- Add allow_unsafe_werkzeug flag for standalone component usage.
- Add app_theme.py to demonstrate theming capabilities.
- Introduce initial test suite covering themes, configuration, and functional lifecycle.
- Update documentation to reflect new configuration options.